### PR TITLE
Add conda and PyPI builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,72 @@
+name: CD
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  PY_VERSION: 3.12
+
+jobs:
+  pypi-build:
+    name: Build package for PyPI
+    if: github.repository == 'ACCESS-NRI/access-parsers'  # exclude forks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PY_VERSION }}
+
+      - run: |
+          python3 -m pip install --upgrade build && python3 -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release
+          path: dist
+
+  pypi-publish:
+    # Split build and publish to restrict trusted publishing to just this workflow
+    needs: ['pypi-build']
+    name: Publish to PyPI.org
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+
+  conda:
+    name: Build with conda and upload
+    if: github.repository == 'ACCESS-NRI/access-parsers'  # exclude forks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup conda environment
+        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
+        with:
+          miniconda-version: "latest"
+          python-version: ${{ env.PY_VERSION }}
+          environment-file: conda/environment.yml
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+
+      - name: Build and upload conda package
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.0.0
+        with:
+          meta_yaml_dir: conda
+          user: ${{ vars.ANACONDA_USER }}
+          label: main
+          token: ${{ secrets.ANACONDA_TOKEN }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: access-parsers
+name: CI
 
 on:
   push:
@@ -11,6 +11,9 @@ on:
 
 permissions:
   contents: read
+
+env:
+  PY_VERSION_BUILD: 3.12
 
 jobs:
   formatting:
@@ -22,6 +25,43 @@ jobs:
       with:
         options: "--check --verbose --diff"
         src: "./src ./tests"
+
+  pypa-build:
+    name: PyPA build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PY_VERSION_BUILD }}
+          cache: 'pip' # caching pip dependencies
+
+      - run: |
+          python3 -m pip install --upgrade build && python3 -m build
+
+  conda-build:
+    name: Conda Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup conda environment
+        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
+        with:
+          miniconda-version: "latest"
+          python-version: ${{ env.PY_VERSION_BUILD }}
+          environment-file: conda/environment.yml
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+
+      - name: Build conda package
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.0.0
+        with:
+          meta_yaml_dir: conda
+          label: main
+          upload: false
 
   build:
     needs: formatting

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -1,0 +1,10 @@
+channels:
+  - conda-forge
+  - accessnri
+  - default
+
+dependencies:
+  - anaconda-client
+  - conda-build
+  - conda-verify
+  - setuptools_scm

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,42 @@
+{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
+{% set version = data.get('version') %}
+{% set pyproj = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
+{% set project = pyproj.get('project') %}
+
+package:
+    name: access-parsers
+    version: "{{ version }}"
+
+build:
+    noarch: python
+    number: 0
+    script: "{{ PYTHON }}  -m pip install . -vv"
+    entry_points:
+        {% for name, script in project.get('scripts', {}).items() %}
+        - {{ name }} = {{ script }}
+        {% endfor %}
+
+source:
+    path: ../
+
+requirements:
+    host:
+        - python
+        - pip
+        - setuptools >=61.0.0
+        - setuptools_scm
+    run:
+        - python >=3.10
+        {% for dep in project.get('dependencies', []) %}
+        - {{ dep }}
+        {% endfor %}
+
+test:
+    imports:
+        - access.parsers
+
+about:
+    home: https://github.com/ACCESS-NRI/access-parsers/
+    license: Apache Software
+    license_family: APACHE
+    summary: "Various functions to read and write configuration files for the models developed at ACCESS-NRI."

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+# This file is only needed for the automatic versioning in the conda recipe
+from setuptools import setup
+import setuptools_scm
+
+setup(version=setuptools_scm.get_version())


### PR DESCRIPTION
Add CI tests and a CD workflow to build and deploy Conda and PyPI packages. Code was mostly copied from other ACCESS projects.